### PR TITLE
[Feat] #18 Apply dark mode

### DIFF
--- a/components/BorderButton/BorderButton.module.scss
+++ b/components/BorderButton/BorderButton.module.scss
@@ -1,10 +1,10 @@
 .btn {
   font-size: 1.2rem;
-  font-weight: 500;
-  width: 100%;
-  border-radius: 4px;
   box-shadow: 1px 1px 2px rgba(35, 35, 35, 0.75);
   transition: all 0.3s ease 0s;
+  padding: 0.625rem 1rem;
+  border: 0;
+  background-color: black;
+  color: #fff;
   cursor: pointer;
-  background-color: red;
 }

--- a/components/Chart/Chart.module.scss
+++ b/components/Chart/Chart.module.scss
@@ -1,50 +1,30 @@
 .ly_chart {
-  text-align: center;
-  width: 100%;
-  & > ul {
-    width: 100%;
-    display: inline-flex;
-    justify-content: space-around;
-    color: #adb5bd;
-  }
-}
-
-#chart {
   border: 1px solid #adb5bd;
   padding-left: 0;
   padding-right: 0;
   margin-left: auto;
   margin-right: auto;
-  margin-top: 100px;
-  display: block;
+  margin-bottom: 1.5rem;
   width: 100%;
-}
 
-.chart__view {
-  font-size: 14px;
-  margin-top: 10px;
-  margin-bottom: 15px;
-  cursor: pointer;
-}
+  & > ul {
+    width: 100%;
+    display: inline-flex;
+    justify-content: space-around;
+    padding-bottom: 7px;
+    color: #adb5bd;
 
-.chart__view .active {
-  border-bottom: 2px solid #adb5bd;
-  padding-bottom: 5px;
-}
+    .bl_chartViewMenu {
+      cursor: pointer;
 
-.chart__info__item {
-  text-align: left;
-  display: flex;
-  flex-flow: row wrap;
-  align-items: center;
-  margin-bottom: 20px;
-  margin-left: 5px;
-  border-bottom: 1px solid #e9ecef;
-}
+      &_item {
+        font-size: 14px;
 
-.chart__info__item > div {
-  text-align: left;
-  padding-right: 13.3%;
-  width: 185px;
-  font-size: 15px;
+        &.is_active {
+          border-bottom: 2px solid #adb5bd;
+          color: var(--theme-page-text);
+        }
+      }
+    }
+  }
 }

--- a/components/Chart/index.tsx
+++ b/components/Chart/index.tsx
@@ -1,19 +1,24 @@
 import { useRef } from 'react';
-import classes from './chart.module.scss';
+import clsx from 'clsx';
+
+import styles from './Chart.module.scss';
 
 const Chart = (): JSX.Element => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
 
   return (
-    <div className={classes.ly_chart}>
-      <canvas ref={canvasRef} id="chart"></canvas>
-      <ul className={classes.chart__view}>
-        <li className={classes.active}>1일</li>
-        <li>1주</li>
-        <li>1달</li>
-        <li>1년</li>
-        <li>5년</li>
-        <li>최대</li>
+    <div className={styles.ly_chart}>
+      <canvas ref={canvasRef}></canvas>
+
+      <ul className={styles.bl_chartViewMenu}>
+        <li className={clsx(styles.bl_chartViewMenu_item, styles.is_active)}>
+          1일
+        </li>
+        <li className={styles.bl_chartViewMenu_item}>1주</li>
+        <li className={styles.bl_chartViewMenu_item}>1달</li>
+        <li className={styles.bl_chartViewMenu_item}>1년</li>
+        <li className={styles.bl_chartViewMenu_item}>5년</li>
+        <li className={styles.bl_chartViewMenu_item}>최대</li>
       </ul>
     </div>
   );

--- a/components/DetailHeader/DetailHeader.module.scss
+++ b/components/DetailHeader/DetailHeader.module.scss
@@ -1,22 +1,20 @@
 .ly_header_nav {
   display: flex;
-  background: #fff;
   justify-content: space-around;
   align-items: center;
   width: 100%;
   height: 30px;
-  border: 1px solid #dee2e6;
-  margin-bottom: 5px;
-
+  border-bottom: 1px solid #dee2e6;
+  margin-bottom: 10px;
   padding: 20px;
-}
 
-.ly_header_nav_cat {
-  text-decoration: none;
-  color: #adb5bd;
-  font-size: 12px;
-}
+  &_cat {
+    text-decoration: none;
+    color: #adb5bd;
+    font-size: 12px;
 
-.ly_header_nav_cat > .active {
-  color: black;
+    & > .active {
+      color: var(--theme-page-text);
+    }
+  }
 }

--- a/components/DetailHeader/index.tsx
+++ b/components/DetailHeader/index.tsx
@@ -1,4 +1,5 @@
 import { NextComponentType } from 'next';
+
 import classes from './DetailHeader.module.scss';
 
 const DetailHeader: NextComponentType = () => {

--- a/components/Header/Header.module.scss
+++ b/components/Header/Header.module.scss
@@ -10,13 +10,6 @@
     .ly_btnWrapper {
       display: flex;
       align-items: center;
-      text-align: right;
-
-      i {
-        color: #000;
-        padding: 0 5px;
-        font-size: 1.25rem;
-      }
     }
   }
 }

--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -1,5 +1,6 @@
-import Logo from '../Logo';
 import styles from './Header.module.scss';
+
+import Logo from '../Logo';
 
 const Header = ({ children }: { children?: React.ReactNode }): JSX.Element => {
   return (

--- a/components/IconButton/IconButton.module.scss
+++ b/components/IconButton/IconButton.module.scss
@@ -1,8 +1,9 @@
-.el_btn {
+.el_iconBtn {
   outline: 0;
   border: none;
   background: none;
   line-height: 1;
+  margin-left: 10px;
 
   &:focus {
     outline: none;

--- a/components/IconButton/index.tsx
+++ b/components/IconButton/index.tsx
@@ -15,7 +15,7 @@ const IconButton = ({
 }): JSX.Element => {
   return (
     <button
-      className={styles.el_btn}
+      className={styles.el_iconBtn}
       style={{ width: width, height: height, backgroundColor: backgroundColor }}
       onClick={onClick}
     >

--- a/components/NavBar/NavBar.module.scss
+++ b/components/NavBar/NavBar.module.scss
@@ -28,11 +28,11 @@
 
     &:focus,
     &:hover {
-      color: #fff;
+      color: var(--theme-page-background);
     }
 
     &.is_active {
-      color: #fff;
+      color: var(--theme-page-background);
     }
 
     &::before {

--- a/components/StockDetail/StockDetail.module.scss
+++ b/components/StockDetail/StockDetail.module.scss
@@ -11,11 +11,6 @@
       display: flex;
       align-items: center;
       text-align: right;
-
-      i {
-        font-size: 1.25rem;
-        margin-left: 8px;
-      }
     }
   }
 }
@@ -63,4 +58,9 @@
     height: 300px;
     background-color: red;
   }
+}
+
+// 다크모드 적용 아이콘
+.el_darkModeIcon {
+  color: var(--theme-btn-text) !important;
 }

--- a/components/StockDetail/index.tsx
+++ b/components/StockDetail/index.tsx
@@ -1,3 +1,5 @@
+import clsx from 'clsx';
+
 import styles from './StockDetail.module.scss';
 
 import StockInfoList from '../StockInfoList';
@@ -11,8 +13,13 @@ const StockDetail = (): JSX.Element => {
     <>
       <Header>
         <IconButton>
-          <i className={(styles.el_btn, 'fas fa-search')} />
-          <i className={(styles.el_btn, 'far fa-star')} />
+          <i
+            className={clsx('fas fa-search fa-2x', styles.el_darkModeIcon)}
+            aria-hidden="true"
+          />
+        </IconButton>
+        <IconButton>
+          <i className={clsx('far fa-star fa-2x', styles.el_darkModeIcon)} />
         </IconButton>
       </Header>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,18 +10,22 @@
       "dependencies": {
         "@types/node": "^17.0.14",
         "classnames": "^2.3.1",
+        "clsx": "^1.1.1",
         "eslint-config-prettier": "^8.3.0",
         "husky": "^7.0.4",
         "lint-staged": "^12.2.2",
         "next": "^12.0.10",
+        "next-themes": "^0.0.15",
         "prettier": "^2.5.1",
         "react": "17.0.2",
         "react-dom": "17.0.2",
         "react-google-login": "^5.2.2",
+        "react-toggle": "^4.1.2",
         "sass": "^1.49.0"
       },
       "devDependencies": {
         "@types/react": "17.0.38",
+        "@types/react-toggle": "^4.0.3",
         "@typescript-eslint/eslint-plugin": "^5.10.0",
         "@typescript-eslint/parser": "^5.10.0",
         "eslint": "8.7.0",
@@ -364,6 +368,15 @@
         "@types/prop-types": "*",
         "@types/scheduler": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-toggle": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/react-toggle/-/react-toggle-4.0.3.tgz",
+      "integrity": "sha512-57QdMWeeQdRjM2/p+udgYerxUbSkmeUIW18kwUttcci6GHkgxoqCsDZfRtsCsAHcvvM5VBQdtDUEgLWo2e87mA==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/scheduler": {
@@ -944,6 +957,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
+      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/commander": {
@@ -2740,6 +2761,16 @@
         }
       }
     },
+    "node_modules/next-themes": {
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.0.15.tgz",
+      "integrity": "sha512-LTmtqYi03c4gMTJmWwVK9XkHL7h0/+XrtR970Ujvtu3s0kZNeJN24aJsi4rkZOI8i19+qq6f8j+8Duwy5jqcrQ==",
+      "peerDependencies": {
+        "next": "*",
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -3130,6 +3161,19 @@
       "peerDependencies": {
         "react": "^16 || ^17",
         "react-dom": "^16 || ^17"
+      }
+    },
+    "node_modules/react-toggle": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/react-toggle/-/react-toggle-4.1.2.tgz",
+      "integrity": "sha512-4Ohw31TuYQdhWfA6qlKafeXx3IOH7t4ZHhmRdwsm1fQREwOBGxJT+I22sgHqR/w8JRdk+AeMCJXPImEFSrNXow==",
+      "dependencies": {
+        "classnames": "^2.2.5"
+      },
+      "peerDependencies": {
+        "prop-types": ">= 15.3.0 < 18",
+        "react": ">= 15.3.0 < 18",
+        "react-dom": ">= 15.3.0 < 18"
       }
     },
     "node_modules/readdirp": {
@@ -4037,6 +4081,15 @@
         "csstype": "^3.0.2"
       }
     },
+    "@types/react-toggle": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/react-toggle/-/react-toggle-4.0.3.tgz",
+      "integrity": "sha512-57QdMWeeQdRjM2/p+udgYerxUbSkmeUIW18kwUttcci6GHkgxoqCsDZfRtsCsAHcvvM5VBQdtDUEgLWo2e87mA==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@types/scheduler": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
@@ -4414,6 +4467,11 @@
         "slice-ansi": "^5.0.0",
         "string-width": "^5.0.0"
       }
+    },
+    "clsx": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
+      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
     },
     "commander": {
       "version": "8.3.0",
@@ -5708,6 +5766,12 @@
         "use-subscription": "1.5.1"
       }
     },
+    "next-themes": {
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.0.15.tgz",
+      "integrity": "sha512-LTmtqYi03c4gMTJmWwVK9XkHL7h0/+XrtR970Ujvtu3s0kZNeJN24aJsi4rkZOI8i19+qq6f8j+8Duwy5jqcrQ==",
+      "requires": {}
+    },
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -5973,6 +6037,14 @@
       "requires": {
         "@types/react": "*",
         "prop-types": "^15.6.0"
+      }
+    },
+    "react-toggle": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/react-toggle/-/react-toggle-4.1.2.tgz",
+      "integrity": "sha512-4Ohw31TuYQdhWfA6qlKafeXx3IOH7t4ZHhmRdwsm1fQREwOBGxJT+I22sgHqR/w8JRdk+AeMCJXPImEFSrNXow==",
+      "requires": {
+        "classnames": "^2.2.5"
       }
     },
     "readdirp": {

--- a/package.json
+++ b/package.json
@@ -9,20 +9,24 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "classnames": "^2.3.1",
     "@types/node": "^17.0.14",
+    "classnames": "^2.3.1",
+    "clsx": "^1.1.1",
     "eslint-config-prettier": "^8.3.0",
     "husky": "^7.0.4",
     "lint-staged": "^12.2.2",
     "next": "^12.0.10",
+    "next-themes": "^0.0.15",
     "prettier": "^2.5.1",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-google-login": "^5.2.2",
+    "react-toggle": "^4.1.2",
     "sass": "^1.49.0"
   },
   "devDependencies": {
     "@types/react": "17.0.38",
+    "@types/react-toggle": "^4.0.3",
     "@typescript-eslint/eslint-plugin": "^5.10.0",
     "@typescript-eslint/parser": "^5.10.0",
     "eslint": "8.7.0",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,8 +2,10 @@ import { useState, useEffect } from 'react';
 import Router from 'next/router';
 import type { AppProps } from 'next/app';
 import Head from 'next/head';
+import { ThemeProvider } from 'next-themes';
 
 import '../styles/globals.scss';
+import '../styles/theme.scss';
 
 import Spinner from '../components/ui/spinner';
 import NavBar from '../components/NavBar/NavBar';
@@ -41,7 +43,9 @@ function MyApp({ Component, pageProps }: AppProps) {
         />
       </Head>
       {isLoading && <Spinner />}
-      <Component {...pageProps} />
+      <ThemeProvider attribute="class">
+        <Component {...pageProps} />
+      </ThemeProvider>
       <NavBar />
     </>
   );

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,7 @@
 import type { NextPage } from 'next';
 import Head from 'next/head';
 import Image from 'next/image';
+
 import styles from '../styles/Home.module.scss';
 
 const Home: NextPage = () => {

--- a/pages/market/Market.module.scss
+++ b/pages/market/Market.module.scss
@@ -1,3 +1,6 @@
 .ly_market {
   min-height: 100vh;
+
+  background: var(--theme-page-background);
+  color: var(--theme-page-text);
 }

--- a/pages/more/index.tsx
+++ b/pages/more/index.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+import Head from 'next/head';
+import { useTheme } from 'next-themes';
+import Toggle from 'react-toggle';
+
+import styles from './more.module.scss';
+import 'react-toggle/style.css';
+
+export default function More() {
+  const [isMounted, setIsMounted] = useState(false);
+  const { theme, setTheme } = useTheme();
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  const switchTheme = () => {
+    if (isMounted) {
+      setTheme(theme === 'light' ? 'dark' : 'light');
+    }
+  };
+
+  return (
+    <div className={styles.ly_more}>
+      <Head>
+        <title>Dark mode with SCSS and Next.js</title>
+        <link rel="icon" href="/favicon.ico" />
+      </Head>
+
+      <h1>Dark mode with SCSS and Next- themes</h1>
+
+      <div className={styles.ly_more_darkModeBtnWrapper}>
+        <Toggle
+          className="el_darkModeToggle"
+          checked={isMounted && theme === 'light'}
+          onChange={switchTheme}
+          icons={{ checked: '🌙', unchecked: '🔆' }}
+          aria-label="Dark mode"
+        />
+      </div>
+    </div>
+  );
+}

--- a/pages/more/more.module.scss
+++ b/pages/more/more.module.scss
@@ -1,0 +1,7 @@
+.ly_more {
+  min-height: 100vh;
+
+  &_darkModeBtnWrapper {
+    width: 100%;
+  }
+}

--- a/styles/Home.module.scss
+++ b/styles/Home.module.scss
@@ -1,3 +1,18 @@
 @import 'mixins';
 @import 'variables';
 @import 'fonts';
+
+.container {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  background: var(--theme-page-background);
+  color: var(--theme-page-text);
+}
+
+.darkModeBtnWrapper {
+  width: 100%;
+}

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -52,3 +52,22 @@ table {
   filter: invert(80%) sepia(0%) saturate(0%) hue-rotate(84deg) brightness(102%)
     contrast(95%);
 }
+
+.react-toggle-track {
+  width: 60px;
+
+  > * {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 13px;
+  }
+}
+
+.react-toggle:hover:not(.react-toggle--disabled) .react-toggle-track {
+  background-color: white !important;
+}
+
+.react-toggle--checked:hover:not(.react-toggle--disabled) .react-toggle-track {
+  background-color: black !important;
+}

--- a/styles/theme.scss
+++ b/styles/theme.scss
@@ -1,0 +1,19 @@
+// _variables.scss로 색상 이동 필요
+
+.light {
+  --theme-color: #a80000;
+  --theme-page-background: #fff;
+  --theme-page-text: #111;
+
+  --theme-btn-text: #111;
+  --theme-btn-background: #a80000;
+}
+
+.dark {
+  --theme-color: #0000a8;
+  --theme-page-background: #111;
+  --theme-page-text: #fff;
+
+  --theme-btn-text: #fff;
+  --theme-btn-background: #0000a8;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -109,6 +109,13 @@
   "resolved" "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz"
   "version" "15.7.4"
 
+"@types/react-toggle@^4.0.3":
+  "integrity" "sha512-57QdMWeeQdRjM2/p+udgYerxUbSkmeUIW18kwUttcci6GHkgxoqCsDZfRtsCsAHcvvM5VBQdtDUEgLWo2e87mA=="
+  "resolved" "https://registry.npmjs.org/@types/react-toggle/-/react-toggle-4.0.3.tgz"
+  "version" "4.0.3"
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*", "@types/react@17.0.38":
   "integrity" "sha512-SI92X1IA+FMnP3qM5m4QReluXzhcmovhZnLNm3pyeQlooi02qI7sLiepEYqT678uNiyc25XfCqxREFpy3W7YhQ=="
   "resolved" "https://registry.npmjs.org/@types/react/-/react-17.0.38.tgz"
@@ -408,7 +415,7 @@
   optionalDependencies:
     "fsevents" "~2.3.2"
 
-"classnames@^2.3.1":
+"classnames@^2.2.5", "classnames@^2.3.1":
   "integrity" "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
   "resolved" "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz"
   "version" "2.3.1"
@@ -440,6 +447,11 @@
   dependencies:
     "slice-ansi" "^5.0.0"
     "string-width" "^5.0.0"
+
+"clsx@^1.1.1":
+  "integrity" "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
+  "resolved" "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz"
+  "version" "1.1.1"
 
 "color-convert@^2.0.1":
   "integrity" "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="
@@ -1432,7 +1444,12 @@
   "resolved" "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
   "version" "1.4.0"
 
-"next@^12.0.10", "next@>=10.2.0":
+"next-themes@^0.0.15":
+  "integrity" "sha512-LTmtqYi03c4gMTJmWwVK9XkHL7h0/+XrtR970Ujvtu3s0kZNeJN24aJsi4rkZOI8i19+qq6f8j+8Duwy5jqcrQ=="
+  "resolved" "https://registry.npmjs.org/next-themes/-/next-themes-0.0.15.tgz"
+  "version" "0.0.15"
+
+"next@*", "next@^12.0.10", "next@>=10.2.0":
   "integrity" "sha512-1y3PpGzpb/EZzz1jgne+JfZXKAVJUjYXwxzrADf/LWN+8yi9o79vMLXpW3mevvCHkEF2sBnIdjzNn16TJrINUw=="
   "resolved" "https://registry.npmjs.org/next/-/next-12.0.10.tgz"
   "version" "12.0.10"
@@ -1640,7 +1657,7 @@
   "resolved" "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz"
   "version" "2.5.1"
 
-"prop-types@^15.6.0", "prop-types@^15.7.2":
+"prop-types@^15.6.0", "prop-types@^15.7.2", "prop-types@>= 15.3.0 < 18":
   "integrity" "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="
   "resolved" "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz"
   "version" "15.8.1"
@@ -1659,7 +1676,7 @@
   "resolved" "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz"
   "version" "1.2.3"
 
-"react-dom@^16 || ^17", "react-dom@^17.0.2 || ^18.0.0-0", "react-dom@17.0.2":
+"react-dom@*", "react-dom@^16 || ^17", "react-dom@^17.0.2 || ^18.0.0-0", "react-dom@>= 15.3.0 < 18", "react-dom@17.0.2":
   "integrity" "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA=="
   "resolved" "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz"
   "version" "17.0.2"
@@ -1681,7 +1698,14 @@
   "resolved" "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
   "version" "16.13.1"
 
-"react@^16 || ^17", "react@^16.8.0 || ^17.0.0", "react@^17.0.2 || ^18.0.0-0", "react@>= 16.8.0 || 17.x.x || 18.x.x", "react@17.0.2":
+"react-toggle@^4.1.2":
+  "integrity" "sha512-4Ohw31TuYQdhWfA6qlKafeXx3IOH7t4ZHhmRdwsm1fQREwOBGxJT+I22sgHqR/w8JRdk+AeMCJXPImEFSrNXow=="
+  "resolved" "https://registry.npmjs.org/react-toggle/-/react-toggle-4.1.2.tgz"
+  "version" "4.1.2"
+  dependencies:
+    "classnames" "^2.2.5"
+
+"react@*", "react@^16 || ^17", "react@^16.8.0 || ^17.0.0", "react@^17.0.2 || ^18.0.0-0", "react@>= 15.3.0 < 18", "react@>= 16.8.0 || 17.x.x || 18.x.x", "react@17.0.2":
   "integrity" "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA=="
   "resolved" "https://registry.npmjs.org/react/-/react-17.0.2.tgz"
   "version" "17.0.2"


### PR DESCRIPTION
## 🍀 개요

다크모드 기능 추가

## ✏️ 작업 내용

- [x] 다크모드 적용(next-themes, react-toggle, clsx 사용) 5d77f556ca46557092e83ce5525129c1d62ac6f6

## 🔎 추가 정보
* 클래스로 테마를 설정하기 위해 next-themes의 ThemeProvider(pages/_app.tsx)에 attribute를 'class'로 전달한다.
테마를 dark로 설정하면 html element에 class="dark"가 설정된다.
* styles/theme.scss의 light 클래스와 dark 클래스에 적용한 컬러는 임시로 적용한 것으로 확정된 컬러는 없다. 
* 두 클래스 내부에 존재하는 CSS variables는 다른 클래스에서 사용해야 할 때 예를 들면 `color : var(--theme-color)` 와 같이 사용하면 된다.
* 컬러가 확정된 후에는 styles/_variables.scss에서 변수로 선언해 일괄적으로 관리하고 변경한다.

![image](https://user-images.githubusercontent.com/59217352/153215380-ced58884-be9d-443f-9c0d-710fc89f0757.png)
![image](https://user-images.githubusercontent.com/59217352/153215543-a8ee1e53-6609-4ab0-8ee3-643c7ad77f0c.png)

![image](https://user-images.githubusercontent.com/59217352/153215124-6aa02174-2a2d-47cd-ab74-d1e231927998.png)

![image](https://user-images.githubusercontent.com/59217352/153215443-1d701049-667c-4fb6-bb1c-4ee5fa2112dc.png)

#18 