### PR TITLE
[Feat] #32 Chart resize

### DIFF
--- a/components/Chart/ChartCanvas.module.scss
+++ b/components/Chart/ChartCanvas.module.scss
@@ -1,3 +1,4 @@
-// .el_canvas {
-//   border: 1px solid #adb5bd;
-// }
+.el_canvas {
+  width: 100%;
+  height: 100%;
+}

--- a/components/Chart/ChartCanvas.tsx
+++ b/components/Chart/ChartCanvas.tsx
@@ -28,8 +28,8 @@ function ChartCanvas({ data }: CanvasProps): JSX.Element {
     <canvas
       className={styles.el_canvas}
       ref={canvasRef}
-      height={window.innerHeight / 2}
-      width={window.innerWidth - 5}
+      height={window.innerHeight}
+      width={window.innerWidth * 2}
     />
   );
 }

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -9,6 +9,7 @@
   box-sizing: border-box;
   font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
     Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+  font-size: 10px;
   text-decoration: none;
   outline: none;
   &::-webkit-scrollbar {

--- a/utils/chart/chart.ts
+++ b/utils/chart/chart.ts
@@ -1,9 +1,10 @@
 import { formatDate } from '../formatDate';
 import { Candle, Line, TimeLineData } from './types';
 
-const chartStyle = {
+export const chartStyle = {
   AXIS_COLOR: '#bbb',
-  FONT: '10.5px Sans-serif',
+  FONT: '1.8rem Sans-serif',
+  SPACING: 25,
 };
 
 export default class Chart<T = Candle | Line> {
@@ -27,8 +28,8 @@ export default class Chart<T = Candle | Line> {
 
   constructor(ctx: CanvasRenderingContext2D) {
     this.ctx = ctx;
-    this.width = ctx.canvas.width - 50;
-    this.height = ctx.canvas.height - 50;
+    this.width = ctx.canvas.width - 100;
+    this.height = ctx.canvas.height - 100;
     this._chartData = [];
     this._timeLineData = [];
     this.maxPrice = -Infinity;
@@ -37,41 +38,41 @@ export default class Chart<T = Candle | Line> {
     this.minPeriod = +Infinity;
   }
 
-  drawXYAxis() {
-    this.ctx.beginPath();
-    this.ctx.strokeStyle = chartStyle.AXIS_COLOR;
-    this.ctx.moveTo(this.width, 0);
-    this.ctx.lineTo(this.width, this.height);
-    this.ctx.lineTo(0, this.height);
-    this.ctx.stroke();
-  }
-
   drawYAxisText(gridNum: number) {
-    const BASIC_MARGIN = 10;
+    const XAXIS_MARGIN = 8;
+    const YAXIS_MARGIN = 4.5;
     const MAX_MIN_DIFF = this.maxPrice - this.minPrice;
 
     for (let i = 0; i <= gridNum; i++) {
       this.ctx.fillText(
         `${(this.maxPrice - (MAX_MIN_DIFF / gridNum) * i).toFixed(2)}`,
-        this.width + BASIC_MARGIN,
-        (this.height / gridNum) * i + 4.5 // fontsize / 2 - strokeWeight / 2
+        this.width + XAXIS_MARGIN + chartStyle.SPACING,
+        (this.height / gridNum) * i + YAXIS_MARGIN + chartStyle.SPACING
       );
     }
   }
 
   drawXAxisText(gridNum: number) {
-    const BASIC_MARGIN = 15;
+    const YAXIS_MARGIN = 30;
+    const XAXIS_MARGIN = 19;
+    const TEXT_MARGIN = 15;
     const period = this.maxPeriod - this.minPeriod;
 
     for (let i = 0; i <= gridNum; i++) {
-      const date = formatDate(this.minPeriod + (period / gridNum) * i);
-      date.forEach((day, idx) => {
-        this.ctx.fillText(
-          day,
-          (this.width / gridNum) * i - BASIC_MARGIN,
-          this.height + BASIC_MARGIN * idx + 10
-        );
-      });
+      const { year, month } = formatDate(
+        this.minPeriod + (period / gridNum) * i
+      );
+
+      this.ctx.fillText(
+        year,
+        (this.width / gridNum) * i + chartStyle.SPACING - XAXIS_MARGIN,
+        this.height + chartStyle.SPACING + YAXIS_MARGIN
+      );
+      this.ctx.fillText(
+        month,
+        (this.width / gridNum) * i + chartStyle.SPACING - XAXIS_MARGIN,
+        this.height + chartStyle.SPACING + TEXT_MARGIN + YAXIS_MARGIN
+      );
     }
   }
 
@@ -79,11 +80,23 @@ export default class Chart<T = Candle | Line> {
     this.ctx.beginPath();
     this.ctx.strokeStyle = chartStyle.AXIS_COLOR;
 
-    for (let i = 0; i < gridNum; i++) {
-      this.ctx.moveTo(0, (this.height / gridNum) * (gridNum - i));
-      this.ctx.lineTo(this.width, (this.height / gridNum) * (gridNum - i));
-      this.ctx.moveTo((this.width / gridNum) * (gridNum - i), 0);
-      this.ctx.lineTo((this.width / gridNum) * (gridNum - i), this.height);
+    for (let i = 0; i <= gridNum; i++) {
+      this.ctx.moveTo(
+        chartStyle.SPACING,
+        (this.height / gridNum) * (gridNum - i) + chartStyle.SPACING
+      );
+      this.ctx.lineTo(
+        this.width + chartStyle.SPACING,
+        (this.height / gridNum) * (gridNum - i) + chartStyle.SPACING
+      );
+      this.ctx.moveTo(
+        (this.width / gridNum) * (gridNum - i) + chartStyle.SPACING,
+        chartStyle.SPACING
+      );
+      this.ctx.lineTo(
+        (this.width / gridNum) * (gridNum - i) + chartStyle.SPACING,
+        this.height + chartStyle.SPACING
+      );
     }
 
     this.ctx.stroke();
@@ -93,7 +106,6 @@ export default class Chart<T = Candle | Line> {
     this.ctx.clearRect(0, 0, this.width, this.height);
     this.ctx.font = chartStyle.FONT;
 
-    this.drawXYAxis();
     this.drawGrid(6);
     this.drawXAxisText(6);
     this.drawYAxisText(6);

--- a/utils/chart/charts.ts
+++ b/utils/chart/charts.ts
@@ -1,5 +1,6 @@
 import Chart from './chart';
 import { Candle, CandleChartOption, CandleData, TimeLineData } from './types';
+import { chartStyle } from './chart';
 
 export default class CandleChart extends Chart<Candle> {
   options: CandleChartOption;
@@ -56,15 +57,21 @@ export default class CandleChart extends Chart<Candle> {
       const yCPoint = yOpenPoint === c ? c + this.ctx.lineWidth : c;
 
       this.ctx.beginPath();
-      this.ctx.moveTo(xPoint, h);
-      this.ctx.lineTo(xPoint, l);
+      this.ctx.moveTo(xPoint + chartStyle.SPACING, h + chartStyle.SPACING);
+      this.ctx.lineTo(xPoint + chartStyle.SPACING, l + chartStyle.SPACING);
       this.ctx.stroke();
 
       this.ctx.lineWidth =
         (widthPercent / 100) * (100 - (this.options.margin as number));
       this.ctx.beginPath();
-      this.ctx.moveTo(xPoint, yOpenPoint);
-      this.ctx.lineTo(xPoint, yCPoint);
+      this.ctx.moveTo(
+        xPoint + chartStyle.SPACING,
+        yOpenPoint + chartStyle.SPACING
+      );
+      this.ctx.lineTo(
+        xPoint + chartStyle.SPACING,
+        yCPoint + chartStyle.SPACING
+      );
       this.ctx.stroke();
     });
   }

--- a/utils/formatDate.ts
+++ b/utils/formatDate.ts
@@ -3,5 +3,5 @@ const formatUSDate = (unixTime: number) =>
 
 export const formatDate = (unixTime: number) => {
   const [day, month, year] = formatUSDate(unixTime).slice(0, 10).split('/');
-  return [`${year}`, `${month}-${day}`];
+  return { year, month: `${month}-${day}` };
 };


### PR DESCRIPTION
## 🍀 개요

- 차트 여백 조정 및 사이즈 조정
- 차트 해상도 조절 전
<img width="700" alt="스크린샷 2022-02-14 오후 10 05 04" src="https://user-images.githubusercontent.com/65802921/154398150-3f9638a9-23a2-4d30-ba3f-d43e3232e6f4.png">

- 차트 해상도 조절 후
<img width="1001" alt="스크린샷 2022-02-17 오후 12 17 50" src="https://user-images.githubusercontent.com/65802921/154398297-6721a788-932d-4870-8677-e01706e44ef5.png">

## ✏️ 작업 내용

- [x] 차트 해상도 조절 - 5f866b53b53f0aa915564308250af87038bab59a
- [x] 차트 사이즈 조절 - 161346392d5123c949ac78fbbecefecf386e74ca
- [x] 글로벌 폰트 사이즈 추가 - a2fb3bf9fc4220d8361113d7fcff64e9b5fcb9ab
