### PR TITLE
[Feat] #54 news page

### DIFF
--- a/components/NewsDetail/NewsDetail.module.scss
+++ b/components/NewsDetail/NewsDetail.module.scss
@@ -1,0 +1,42 @@
+.ly_NewsDetail {
+  max-width: 1230px;
+  min-width: 375px;
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+}
+
+.bl_NewsDetail {
+  display: flex;
+  flex-direction: column;
+  padding-left: 5rem;
+  padding-right: 5rem;
+
+  .bl_NewsDetail_ttl > h1 {
+    font-size: 3rem;
+    margin-bottom: 5px;
+    text-align: center;
+  }
+
+  .bl_NewsDetail_prov {
+    font-size: 1.25rem;
+    margin-left: auto;
+    margin-bottom: 5px;
+  }
+
+  .bl_NewsDetail_time {
+    margin-left: auto;
+    margin-bottom: 20px;
+  }
+
+  .bl_NewsDetail_thumb {
+    margin-bottom: 10px;
+    width: 100%;
+    text-align: center;
+  }
+
+  .bl_NewsDetail_desc {
+    font-size: 1.25rem;
+    text-align: left;
+  }
+}

--- a/components/NewsDetail/index.tsx
+++ b/components/NewsDetail/index.tsx
@@ -1,0 +1,51 @@
+import Image from 'next/image';
+import styles from 'components/NewsDetail/NewsDetail.module.scss';
+
+export interface NewsDetailProps {
+  newsDesc: string;
+  contentURL: string;
+  width: string;
+  height: string;
+  newsUrl: string;
+  newsProvider: string;
+  newsDatePublished: string;
+  newsName: string;
+}
+
+export const NewsDetail = ({
+  newsDesc,
+  contentURL,
+  width,
+  height,
+  newsUrl,
+  newsProvider,
+  newsDatePublished,
+  newsName,
+}: NewsDetailProps): JSX.Element => {
+  return (
+    <>
+      <article className={styles.ly_NewsDetail}>
+        <section className={styles.bl_NewsDetail}>
+          {console.log(newsName)}
+          <div className={styles.bl_NewsDetail_ttl}>
+            <h1>{newsName}</h1>
+          </div>
+          <div className={styles.bl_NewsDetail_prov}>{newsProvider}</div>
+          <div className={styles.bl_NewsDetail_time}>{newsDatePublished}</div>
+          <div className={styles.bl_NewsDetail_thumb}>
+            <Image
+              src={`/api/imagefetcher?url=${encodeURIComponent(contentURL)}`}
+              alt="main__news__thumbnail"
+              width={width}
+              height={height}
+            />
+          </div>
+          <div className={styles.bl_NewsDetail_desc}>
+            {newsDesc}
+            <a href={newsUrl}>...원문보기</a>
+          </div>
+        </section>
+      </article>
+    </>
+  );
+};

--- a/components/NewsDetailHeader/NewsDetailHeader.module.scss
+++ b/components/NewsDetailHeader/NewsDetailHeader.module.scss
@@ -1,0 +1,25 @@
+.bl_chartViewMenu {
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  width: 100%;
+  height: 30px;
+  border-bottom: 1px solid #dee2e6;
+  margin-bottom: 10px;
+  padding: 20px;
+
+  &_item {
+    text-decoration: none;
+    color: #adb5bd;
+    font-size: 12px;
+    background-color: transparent;
+    background-repeat: no-repeat;
+    border: none;
+    overflow: hidden;
+    outline: none;
+
+    & > .is_active {
+      color: var(--theme-page-text);
+    }
+  }
+}

--- a/components/NewsDetailHeader/NewsDetailHeader.module.scss
+++ b/components/NewsDetailHeader/NewsDetailHeader.module.scss
@@ -1,4 +1,4 @@
-.bl_chartViewMenu {
+.bl_news_nav {
   display: flex;
   justify-content: space-around;
   align-items: center;
@@ -8,7 +8,7 @@
   margin-bottom: 10px;
   padding: 20px;
 
-  &_item {
+  &_cat {
     text-decoration: none;
     color: #adb5bd;
     font-size: 12px;
@@ -17,9 +17,9 @@
     border: none;
     overflow: hidden;
     outline: none;
-
-    & > .is_active {
-      color: var(--theme-page-text);
-    }
+  }
+  & > .is_active {
+    border-bottom: 2px solid #adb5bd;
+    color: var(--theme-page-text);
   }
 }

--- a/components/NewsDetailHeader/index.tsx
+++ b/components/NewsDetailHeader/index.tsx
@@ -19,7 +19,7 @@ export const NewsDetailHeader = ({
 
   return (
     <>
-      <nav className={styles.bl_chartViewMenu}>
+      <nav className={styles.bl_news_nav}>
         {headerItems.map(({ id, text, value }) => (
           <button
             key={id}
@@ -28,7 +28,7 @@ export const NewsDetailHeader = ({
               setActiveId(id);
             }}
             className={clsx(
-              styles.bl_chartViewMenu_item,
+              styles.bl_news_nav_cat,
               activeId === id && styles.is_active
             )}
           >

--- a/components/NewsDetailHeader/index.tsx
+++ b/components/NewsDetailHeader/index.tsx
@@ -1,0 +1,41 @@
+import styles from 'components/NewsDetailHeader/NewsDetailHeader.module.scss';
+import clsx from 'clsx';
+import { useState } from 'react';
+
+export const NewsDetailHeader = ({
+  setCategory,
+}: {
+  setCategory: (period: string) => void;
+}): JSX.Element => {
+  const [activeId, setActiveId] = useState(1);
+
+  const headerItems = [
+    { id: 1, text: '최신', value: '주식&비트코인&경제&정치' },
+    { id: 2, text: '주식', value: '주식' },
+    { id: 3, text: '암호화폐', value: '비트코인&암호화폐' },
+    { id: 4, text: '경제', value: '경제' },
+    { id: 5, text: '상품', value: '금&은&원유&천연가스&유가&달러' },
+  ];
+
+  return (
+    <>
+      <nav className={styles.bl_chartViewMenu}>
+        {headerItems.map(({ id, text, value }) => (
+          <button
+            key={id}
+            onClick={() => {
+              setCategory(value);
+              setActiveId(id);
+            }}
+            className={clsx(
+              styles.bl_chartViewMenu_item,
+              activeId === id && styles.is_active
+            )}
+          >
+            {text}
+          </button>
+        ))}
+      </nav>
+    </>
+  );
+};

--- a/components/NewsHeadline/NewsHeadline.module.scss
+++ b/components/NewsHeadline/NewsHeadline.module.scss
@@ -1,0 +1,85 @@
+.ly_mainNews {
+  margin-top: 40px;
+  padding-left: 5px;
+  padding-right: 5px;
+  & > a {
+    color: black;
+  }
+  & > a:hover {
+    color: red;
+  }
+  .el_image__l {
+    width: 100%;
+    height: 300px;
+    margin-bottom: 5px;
+  }
+
+  .bl_mainNews {
+    display: flex;
+    align-items: center;
+    font-size: 3rem;
+    text-overflow: ellipsis;
+  }
+
+  .bl_mainNews_info {
+    align-items: center;
+    margin-top: 5px;
+    padding-left: 10px;
+  }
+
+  .bl_mainNews_prov {
+    margin-right: 5px;
+    padding-right: 10px;
+  }
+
+  .bl_mainNews_time {
+    font-size: 8px;
+  }
+}
+
+.ly_newsLink {
+  display: flex;
+  align-items: center;
+  border-top: 1px solid #dee2e6;
+  margin-top: 5px;
+}
+
+.ly_news {
+  padding-left: 5px;
+  padding-right: 5px;
+
+  & > a {
+    color: black;
+  }
+  & > a:hover {
+    color: red;
+  }
+
+  .el_image__s {
+    // width: 33%;
+    margin-right: 10px;
+  }
+
+  .bl_news {
+    margin-top: 10px;
+    padding-left: 15px;
+  }
+
+  .bl_news_ttl {
+    font-size: 1.3rem;
+    text-overflow: ellipsis;
+  }
+
+  .bl_news_info {
+    margin-right: 5px;
+  }
+
+  .bl_news_prov {
+    margin-top: 10px;
+    padding-right: 10px;
+  }
+
+  .bl_news_time {
+    font-size: 8px;
+  }
+}

--- a/components/NewsHeadline/index.tsx
+++ b/components/NewsHeadline/index.tsx
@@ -1,0 +1,79 @@
+import Link from 'next/link';
+import Image from 'next/image';
+
+import { NewsDataType } from 'pages/news';
+
+import styles from 'components/NewsHeadline/NewsHeadline.module.scss';
+
+export const NewsHeadline = ({
+  isMain,
+  newsData,
+}: {
+  isMain: boolean;
+  newsData: NewsDataType;
+}): JSX.Element => {
+  const { name, url, description, image, provider, datePublished } = newsData;
+  return (
+    <>
+      <article
+        className={isMain ? styles.ly_mainNews : styles.ly_news}
+        key={url}
+      >
+        <Link
+          href={{
+            pathname: `/news/[id]`,
+            query: {
+              description: JSON.stringify(description),
+              image: JSON.stringify(image),
+              provider: JSON.stringify(provider),
+              datePublished: JSON.stringify(datePublished),
+              url: JSON.stringify(url),
+              name: JSON.stringify(name),
+            },
+          }}
+          as={`/news/1`}
+        >
+          <a className={!isMain ? styles.ly_newsLink : ''}>
+            <Image
+              src={`/api/imagefetcher?url=${encodeURIComponent(
+                image.contentURL
+              )}`}
+              alt="main news thumbnail"
+              width={isMain ? image.width : 150}
+              height={isMain ? image.height : 150}
+              className={isMain ? styles.el_image__l : styles.el_image__s}
+            />
+
+            <section className={isMain ? styles.bl_mainNews : styles.bl_news}>
+              <span
+                className={isMain ? styles.bl_mainNews_ttl : styles.bl_news_ttl}
+              >
+                {name}
+              </span>
+              <div
+                className={
+                  isMain ? styles.bl_mainNews_info : styles.bl_news_info
+                }
+              >
+                <span
+                  className={
+                    isMain ? styles.bl_mainNews_prov : styles.bl_news_prov
+                  }
+                >
+                  {provider}
+                </span>
+                <span
+                  className={
+                    isMain ? styles.bl_mainNews_time : styles.bl_news_time
+                  }
+                >
+                  {datePublished}
+                </span>
+              </div>
+            </section>
+          </a>
+        </Link>
+      </article>
+    </>
+  );
+};

--- a/pages/api/imagefetcher.ts
+++ b/pages/api/imagefetcher.ts
@@ -1,0 +1,12 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+
+const fn = async (req: NextApiRequest, res: NextApiResponse) => {
+  const url = decodeURIComponent(req.query.url as string);
+  const result = await fetch(url);
+  const body = await result.body;
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  body?.pipe(res);
+};
+
+export default fn;

--- a/pages/news/[id].tsx
+++ b/pages/news/[id].tsx
@@ -1,0 +1,42 @@
+import { WithRouterProps } from 'next/dist/client/with-router';
+import { withRouter } from 'next/router';
+import Header from 'components/Header';
+import IconButton from 'components/IconButton';
+import { faSearch, faStar } from '@fortawesome/free-solid-svg-icons';
+
+import { NewsDetail } from 'components/NewsDetail';
+
+const NewsDetailPage: React.FC<WithRouterProps> = ({
+  router: {
+    query: { description, image, url, provider, datePublished, name },
+  },
+}): JSX.Element => {
+  const { contentURL, width, height } = JSON.parse(image as string);
+  return (
+    <>
+      <Header>
+        <IconButton
+          onClick={() => console.log('검색 자동완성 드롭다운')}
+          icon={faSearch}
+        />
+        <IconButton
+          onClick={() => console.log('관심목록에 추가')}
+          icon={faStar}
+        />
+      </Header>
+
+      <NewsDetail
+        newsDesc={JSON.parse(description as string)}
+        contentURL={contentURL}
+        width={width}
+        height={height}
+        newsUrl={JSON.parse(url as string)}
+        newsProvider={JSON.parse(provider as string)}
+        newsDatePublished={JSON.parse(datePublished as string)}
+        newsName={JSON.parse(name as string)}
+      />
+    </>
+  );
+};
+
+export default withRouter(NewsDetailPage);

--- a/pages/news/[id]/index.tsx
+++ b/pages/news/[id]/index.tsx
@@ -1,0 +1,7 @@
+export const NewsDetail = (): JSX.Element => {
+  return (
+    <>
+      <h1>hi</h1>
+    </>
+  );
+};

--- a/pages/news/index.tsx
+++ b/pages/news/index.tsx
@@ -1,17 +1,17 @@
-import Link from 'next/link';
-import Image from 'next/image';
-import classes from 'pages/news/news.module.scss';
 import Header from 'components/Header';
 import IconButton from 'components/IconButton';
 import { NewsDetailHeader } from 'components/NewsDetailHeader';
 import Spinner from 'components/Spinner';
+import { NewsHeadline } from 'components/NewsHeadline';
+
+import styles from 'pages/news/news.module.scss';
 
 import { faSearch, faStar } from '@fortawesome/free-solid-svg-icons';
 import { NEWS_API } from 'utils/config';
 import useAxios from 'hooks/useAxios';
 import { useState, useEffect } from 'react';
 
-interface NewsDataType {
+export interface NewsDataType {
   name: string;
   url: string;
   image: {
@@ -24,7 +24,7 @@ interface NewsDataType {
   datePublished: string;
 }
 
-type NewsType = NewsDataType[];
+export type NewsType = NewsDataType[];
 
 const NewsPage = (): JSX.Element => {
   const [category, setCategory] = useState('주식&비트코인&경제&정치');
@@ -34,8 +34,6 @@ const NewsPage = (): JSX.Element => {
   useEffect(() => {
     fetchData();
   }, [category]);
-
-  console.log(data);
 
   return (
     <>
@@ -51,64 +49,17 @@ const NewsPage = (): JSX.Element => {
       </Header>
       <main>
         <NewsDetailHeader setCategory={setCategory} />
-        {loading && <Spinner />}
-        {data &&
-          data.map(
-            (
-              { name, url, image, description, provider, datePublished },
-              idx
-            ) => {
+        <section className={styles.ly_news}>
+          {loading && <Spinner />}
+          {data &&
+            data.map((newsData, idx) => {
               if (idx === 0) {
-                return (
-                  <article className={classes.main__news__item} key={url}>
-                    <Image
-                      src={`/api/imagefetcher?url=${encodeURIComponent(
-                        image.contentURL
-                      )}`}
-                      alt="main__news__thumbnail"
-                      width={image.width}
-                      height={image.height}
-                      className={classes.main__news__thumbnail}
-                    />
-                    <section className={classes.main__news__headline}>
-                      <span className={classes.main__news__title}>{name}</span>
-                      <div className={classes.main__news__information}>
-                        <span className={classes.main__news__source}>
-                          {provider}
-                        </span>
-                        <span className={classes.main__news__writtenTime}>
-                          {datePublished}
-                        </span>
-                      </div>
-                    </section>
-                  </article>
-                );
+                return <NewsHeadline isMain={true} newsData={newsData} />;
+              } else {
+                return <NewsHeadline isMain={false} newsData={newsData} />;
               }
-              return (
-                <article className={classes.news__item} key={url}>
-                  <Image
-                    src={`/api/imagefetcher?url=${encodeURIComponent(
-                      image.contentURL
-                    )}`}
-                    alt="news__thumbnail"
-                    width={100}
-                    height={100}
-                    className={classes.news__thumbnail}
-                  />
-                  {console.log(name, image.width, image.height)}
-                  <section className={classes.news__headline}>
-                    <span className={classes.news__title}>{name}</span>
-                    <div className={classes.news__information}>
-                      <span className={classes.news__source}>{provider}</span>
-                      <span className={classes.news__writtenTime}>
-                        {datePublished}
-                      </span>
-                    </div>
-                  </section>
-                </article>
-              );
-            }
-          )}
+            })}
+        </section>
       </main>
     </>
   );

--- a/pages/news/index.tsx
+++ b/pages/news/index.tsx
@@ -1,5 +1,117 @@
-const index = (): JSX.Element => {
-  return <>뉴스페이지</>;
+import Link from 'next/link';
+import Image from 'next/image';
+import classes from 'pages/news/news.module.scss';
+import Header from 'components/Header';
+import IconButton from 'components/IconButton';
+import { NewsDetailHeader } from 'components/NewsDetailHeader';
+import Spinner from 'components/Spinner';
+
+import { faSearch, faStar } from '@fortawesome/free-solid-svg-icons';
+import { NEWS_API } from 'utils/config';
+import useAxios from 'hooks/useAxios';
+import { useState, useEffect } from 'react';
+
+interface NewsDataType {
+  name: string;
+  url: string;
+  image: {
+    contentURL: string;
+    width: number;
+    height: number;
+  };
+  description: string;
+  provider: string;
+  datePublished: string;
+}
+
+type NewsType = NewsDataType[];
+
+const NewsPage = (): JSX.Element => {
+  const [category, setCategory] = useState('주식&비트코인&경제&정치');
+  const { data, loading, fetchData } = useAxios<NewsType>(
+    `${NEWS_API}?queryString=${category}`
+  );
+  useEffect(() => {
+    fetchData();
+  }, [category]);
+
+  console.log(data);
+
+  return (
+    <>
+      <Header>
+        <IconButton
+          onClick={() => console.log('검색 자동완성 드롭다운')}
+          icon={faSearch}
+        />
+        <IconButton
+          onClick={() => console.log('관심목록에 추가')}
+          icon={faStar}
+        />
+      </Header>
+      <main>
+        <NewsDetailHeader setCategory={setCategory} />
+        {loading && <Spinner />}
+        {data &&
+          data.map(
+            (
+              { name, url, image, description, provider, datePublished },
+              idx
+            ) => {
+              if (idx === 0) {
+                return (
+                  <article className={classes.main__news__item} key={url}>
+                    <Image
+                      src={`/api/imagefetcher?url=${encodeURIComponent(
+                        image.contentURL
+                      )}`}
+                      alt="main__news__thumbnail"
+                      width={image.width}
+                      height={image.height}
+                      className={classes.main__news__thumbnail}
+                    />
+                    <section className={classes.main__news__headline}>
+                      <span className={classes.main__news__title}>{name}</span>
+                      <div className={classes.main__news__information}>
+                        <span className={classes.main__news__source}>
+                          {provider}
+                        </span>
+                        <span className={classes.main__news__writtenTime}>
+                          {datePublished}
+                        </span>
+                      </div>
+                    </section>
+                  </article>
+                );
+              }
+              return (
+                <article className={classes.news__item} key={url}>
+                  <Image
+                    src={`/api/imagefetcher?url=${encodeURIComponent(
+                      image.contentURL
+                    )}`}
+                    alt="news__thumbnail"
+                    width={100}
+                    height={100}
+                    className={classes.news__thumbnail}
+                  />
+                  {console.log(name, image.width, image.height)}
+                  <section className={classes.news__headline}>
+                    <span className={classes.news__title}>{name}</span>
+                    <div className={classes.news__information}>
+                      <span className={classes.news__source}>{provider}</span>
+                      <span className={classes.news__writtenTime}>
+                        {datePublished}
+                      </span>
+                    </div>
+                  </section>
+                </article>
+              );
+            }
+          )}
+      </main>
+    </>
+  );
 };
 
-export default index;
+export default NewsPage;

--- a/pages/news/news.module.scss
+++ b/pages/news/news.module.scss
@@ -1,0 +1,60 @@
+.main__news__item {
+  margin-top: 80px;
+}
+
+.main__news__thumbnail {
+  width: 100%;
+  height: 300px;
+  margin-bottom: 5px;
+}
+
+.main__news__title {
+  display: flex;
+  align-items: center;
+  font-size: 16px;
+  text-overflow: ellipsis;
+}
+
+.main__news__information {
+  margin-top: 5px;
+}
+
+.main__news__source {
+  margin-right: 5px;
+}
+
+.main__news__writtenTime {
+  font-size: 8px;
+}
+
+.news__item {
+  display: flex;
+  align-items: center;
+  border-top: 1px solid #dee2e6;
+  margin-top: 5px;
+}
+
+.news__thumbnail {
+  // width: 33%;
+  margin-right: 10px;
+}
+
+.news__headline {
+  margin-top: 10px;
+}
+
+.news__title {
+  text-overflow: ellipsis;
+}
+
+.news__source {
+  margin-right: 5px;
+}
+
+.news__information {
+  margin-top: 10px;
+}
+
+.news__writtenTime {
+  font-size: 8px;
+}

--- a/pages/news/news.module.scss
+++ b/pages/news/news.module.scss
@@ -1,60 +1,9 @@
-.main__news__item {
-  margin-top: 80px;
-}
-
-.main__news__thumbnail {
+.ly_news {
+  max-width: 1230px;
+  min-width: 375px;
   width: 100%;
-  height: 300px;
-  margin-bottom: 5px;
-}
 
-.main__news__title {
-  display: flex;
-  align-items: center;
-  font-size: 16px;
-  text-overflow: ellipsis;
-}
-
-.main__news__information {
-  margin-top: 5px;
-}
-
-.main__news__source {
-  margin-right: 5px;
-}
-
-.main__news__writtenTime {
-  font-size: 8px;
-}
-
-.news__item {
-  display: flex;
-  align-items: center;
-  border-top: 1px solid #dee2e6;
-  margin-top: 5px;
-}
-
-.news__thumbnail {
-  // width: 33%;
-  margin-right: 10px;
-}
-
-.news__headline {
-  margin-top: 10px;
-}
-
-.news__title {
-  text-overflow: ellipsis;
-}
-
-.news__source {
-  margin-right: 5px;
-}
-
-.news__information {
-  margin-top: 10px;
-}
-
-.news__writtenTime {
-  font-size: 8px;
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
 }

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -5,3 +5,4 @@ export const CRYPTO_CANDLE_API = `${SERVER}/crypto/candle`;
 export const STOCK_CANDLE_API = `${SERVER}/stock/candle`;
 export const MARKET_INFO_API = `${SERVER}/market/info`;
 export const QUOTE_API = `${SERVER}/quote`;
+export const NEWS_API = `${SERVER}/news`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1280,9 +1280,9 @@
   dependencies:
     "glob" "7.1.7"
 
-"@next/swc-darwin-arm64@12.0.10":
-  "integrity" "sha512-f2zngulkpIJKWHckhRi7X8GZ+J/tNgFF7lYIh7Qx15JH0OTBsjkqxORlkzy+VZyHJ5sWTCaI6HYYd3ow6qkEEg=="
-  "resolved" "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.0.10.tgz"
+"@next/swc-darwin-x64@12.0.10":
+  "integrity" "sha512-Qykcu/gVC5oTvOQoRBhyuS5GYm5SbcgrFTsaLFkGBmEkg9eMQRiaCswk4IafpDXVzITkVFurzSM28q3tLW2qUw=="
+  "resolved" "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.0.10.tgz"
   "version" "12.0.10"
 
 "@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.3":


### PR DESCRIPTION
## 🍀 개요

뉴스페이지 제작 및 하위 컴포넌트 생성

## ✏️ 작업 내용

- [X] 뉴스 디테일 헤더 컴포넌트 - fde8868bac29d5d98accade383606cb78470974c
<img width="340" alt="스크린샷 2022-02-24 오후 12 30 23" src="https://user-images.githubusercontent.com/65802921/155452706-6b1469ed-9e4f-46d0-8231-e11dbaea87d7.png">

- [X] 뉴스 디테일 헤더 클래스네임 리팩토링 - 576cf19
- [X] 도메인 다른 이미지 불러오는 image fetcher api - 9248241ed0c5a2de6bc520961ebe06a9b8fcddc8
- [X] 뉴스 페이지, 뉴스페이지 스타일링 - 07964ed
- [X] 뉴스 디테일 컴포넌트 - c501366
- [X] 뉴스 헤더라인 컴포넌트 - d94fa4a
