### PR TITLE
[Feat] change format of USDate to 24hours

### DIFF
--- a/utils/formatDate.ts
+++ b/utils/formatDate.ts
@@ -1,6 +1,9 @@
 const getUSDate = () => {
   const d = new Date();
-  return d.toLocaleString('en-US', { timeZone: 'America/New_York' });
+  return d.toLocaleString('en-US', {
+    timeZone: 'America/New_York',
+    hour12: false,
+  });
 };
 // * : for Chart
 const formatUSDate = (unixTime: number) =>


### PR DESCRIPTION
## 🍀 개요

USDate의 타임존을 뉴욕으로 주고 `24시간 형식`으로 바꿔줘야 거래시간 계산이 가능하다.

## ✏️ 작업 내용

- [x] USDate 함수의 Date를 24시간 형식으로 변경 272329b

## 🔎 추가 정보
https://stackoverflow.com/questions/22347521/change-time-format-to-24-hours-in-javascript
<img width="200" alt="image" src="https://user-images.githubusercontent.com/59217352/158504633-26629b27-6f4c-4f0b-a573-aa7614a518fc.png">
<img width="92" alt="image" src="https://user-images.githubusercontent.com/59217352/158505449-f789b0a1-9c36-45d9-9f55-379b3b35bf86.png">

close #100 