### PR TITLE
[Feat] show error message when market data is not available

### DIFF
--- a/components/MarketInfoList/index.tsx
+++ b/components/MarketInfoList/index.tsx
@@ -37,9 +37,11 @@ export interface OpenPriceDataItem {
 }
 
 const MarketInfoList = ({ category }: MarketCategoryProps): JSX.Element => {
-  const { data: marketInfoData, loading } = useAxios<OpenPriceData>(
-    `${QUOTE_API}?category=${category}`
-  );
+  const {
+    data: marketInfoData,
+    loading,
+    error,
+  } = useAxios<OpenPriceData>(`${QUOTE_API}?category=${category}`);
   const [realtimeData, setRealtimeData] = useState<IParsedResponseInput>();
 
   useEffect(() => {
@@ -53,6 +55,12 @@ const MarketInfoList = ({ category }: MarketCategoryProps): JSX.Element => {
   return (
     <>
       {loading && <Spinner />}
+      {error && (
+        <div className="errorMsg">
+          <p>마켓 데이터를 가져오는 데 실패했습니다.</p>
+          <p> 잠시 후에 다시 시도해주세요.</p>
+        </div>
+      )}
       {marketInfoData && (
         <ul className={styles.bl_vertMarketInfo}>
           {marketInfoData.data.map((d) => (

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -82,3 +82,14 @@ table {
 .react-toggle--checked:hover:not(.react-toggle--disabled) .react-toggle-track {
   background-color: black !important;
 }
+
+.errorMsg {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 75vh;
+  font-size: 1.5rem;
+  color: #333;
+  text-align: center;
+}


### PR DESCRIPTION
## 🍀 개요

finnhub.io에서 데이터를 null로 줄 때 에러 메시지를 보여주지 않는 버그에 대한 수정

## ✏️ 작업 내용

- [x] 마켓 페이지에서 데이터를 페칭 시 에러가 발생하면 에러 메시지를 보여주도록 변경 1634055

## 🔎 추가 정보

<img width="338" alt="image" src="https://user-images.githubusercontent.com/59217352/159693461-4fc24300-0ba7-40cf-9b55-05d58aa5f1d7.png">


220322 백엔드 에러 처리 https://github.com/DDSS-FE/DDuck-SSang_BE/commit/9c23f474cf7af36786c6285938c5a90e2064ad26

close #104 